### PR TITLE
Fix activation command (conda --> source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ conda env update
 This downloads all of the dependencies and then all you have to do is:
 
 ```sh
-conda activate fastai
+source activate fastai
 ```
 
 To update everything at any time, cd to your repo and:
@@ -36,6 +36,7 @@ To install a cpu only environment instead:
 ```sh
 cd fastai
 conda env update -f environment-cpu.yml
+source activate fastai-cpu
 ```
 
 You can also install this library in the local environment using ```pip```


### PR DESCRIPTION
`conda activate` is not a command. It should be `source activate`

```
$ conda activate fastai-cpu

CommandNotFoundError: 'activate is not a conda command.
Did you mean 'source activate'?
```